### PR TITLE
chore(gitignore): ignore rendered docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore rendered docs.
+/site


### PR DESCRIPTION
The built docs should be ignored so they don't clutter git status.