### PR TITLE
docs(oauth2): fix example request headers

### DIFF
--- a/docs/api/oauth2.md
+++ b/docs/api/oauth2.md
@@ -26,12 +26,13 @@ scope. Example, to request an access token for the user `tenant` with password
 
 ```http
 POST https://api.itslanguage.nl/tokens HTTP/1.1
-Accept: application/x-www-form-urlencoded
+Content-Type: application/x-www-form-urlencoded
+Accept: application/json
 
 grant_type=password&username=tenant&password=secret&scope=tenant%2Ftenant
 ```
 
-Note the `Content Type` of the POST.
+Note the `Content-Type` of the POST.
 
 ### Response
 


### PR DESCRIPTION
State the correct content type and accepted content type.