### PR TITLE
docs(users): fix list status code

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -71,7 +71,7 @@ Accept: application/json
 ### Response
 
 ```http
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 [


### PR DESCRIPTION
When listing users, a "created" status code does not apply, that
should be an "OK".