### PR TITLE
docs(emailauth): add url for current user

### DIFF
--- a/docs/api/emailauth.md
+++ b/docs/api/emailauth.md
@@ -8,6 +8,14 @@ the REST API. Only users with administrative powers can perform these calls.
 
 ### URL
 
+To create an emailauth for the current user:
+
+```http
+POST /user/emailauths HTTP/1.1
+```
+
+To create an emailauth for another user:
+
 ```http
 POST /users/:user/emailauths HTTP/1.1
 ```


### PR DESCRIPTION
Add a url to create an emailauth for the current user.
This doesn't require a user id to be set in the url.