### PR TITLE
chore(categories): add category API description

### DIFF
--- a/docs/api/categories.md
+++ b/docs/api/categories.md
@@ -1,0 +1,265 @@
+# Cagegories
+
+Categorize Speech Challenges or categories.
+
+## List all top level categories
+
+List all top level categories which do not have a parent category.
+
+### URL
+
+```http
+GET /categories HTTP/1.1
+```
+
+### Request
+
+```http
+GET /categories HTTP/1.1
+Accept: application/json
+```
+
+### Response
+
+The resonse is a JSON list with categories.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "id": "category_1",
+    "created": "2017-01-12T09:35:20Z",
+    "updated": "2017-01-12T09:35:20Z",
+    "name": "Category 1",
+    "description": "Some awesome description.",
+    "color": "#00f",
+    "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+    "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
+    "categories": ["category_1_1", "category_1_2"],
+    "speechChallenges": [],
+    "progress": {
+      "done": 1,
+      "total": 2
+    }
+  },
+  {
+    "id": "category_2",
+    "created": "2017-01-12T09:36:20Z",
+    "updated": "2017-01-12T09:36:20Z",
+    "name": "Category 2",
+    "description": "Another awesome description.",
+    "color": "#0f0",
+    "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+    "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
+    "categories": ["category_2_1", "category_2_2", "category_2_3"],
+    "speechChallenges": [],
+    "progress": {
+      "done": 1,
+      "total": 3
+    }
+  }
+]
+```
+
+# Get a single category
+
+### URL
+
+```http
+GET /category/:category HTTP/1.1
+```
+
+* `category` - **Required** The category identifier.
+
+### Request
+
+```http
+GET /category/category_1_1 HTTP/1.1
+Accept: application/json
+```
+
+### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "category_1_1",
+  "created": "2017-01-12T09:38:20Z",
+  "updated": "2017-01-12T09:38:20Z",
+  "name": "Category 1.1",
+  "description": "Super duper.",
+  "color": "",
+  "imageUrl": "",
+  "iconUrl": "",
+  "categories": [],
+  "speechChallenges": [
+    {
+      "id": "speech_1",
+      "created": "2014-01-28T21:25:10Z",
+      "updated": "2014-01-28T21:25:10Z",
+      "topic": "What do you know about babies?",
+      "referenceAudioUrl": "https://api.itslanguage.nl/download/YsjdG37bUGseu8-bsJ",
+      "srtUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+      "imageUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe"
+    },
+    {
+      "id": "12",
+      "created": "2014-01-28T21:25:10Z",
+      "updated": "2014-01-28T21:25:10Z",
+      "topic": "Book",
+      "referenceAudioUrl": "https://api.itslanguage.nl/download/YsjdG37bUGseu8-bsJ",
+      "srtUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+      "imageUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe"
+    }
+  ],
+  "progress": {
+    "done": 1,
+    "total": 2
+  }
+}
+```
+
+### Create a catetory
+
+### URL
+
+```http
+POST /categories/category HTTP/1.1
+```
+
+### Request parameters
+
+Name               | Type      | Description
+-------------------|-----------|------------
+`id`               | `string`  | **Optional** The category identifier. If none is given, one is generated.
+`name`             | `string`  | **Optional** A name for the category.
+`description`      | `string`  | **Optional** A possible more verbose description about the category.
+`color`            | `string`  | **Optional** A color, preferably in RGB format.
+`image`            | `blob`    | **Optional** An image to show with the category.
+`icon`             | `blob`    | **Optional** An icon to show with the category.
+`categories`       | `object`  | **Optional** An array with category identifiers for nesting categories in a category.
+`speechChallenges` | `object`  | **Optional** An array of Speech Challenges identifiers categorized in the category.
+
+#### Request
+
+```http
+POST /categories/category HTTP/1.1
+Accept: application/json
+Content-Type: multipart/form-data; boundary=jhgd87g7Gy3d78
+
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="id"
+
+category_3
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="name"
+
+Category 3
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="description"
+
+Category three. Winner of all categories. Yes.
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="color"
+
+#e3e3e3
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="image"; filename="img.png"
+Content-Type: image/png
+
+<blob>
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="icon"; filename="icon.png"
+Content-Type: image/png
+
+<blob>
+--jhgd87g7Gy3d78
+Content-Disposition: form-data; name="speechChallenges"
+Content-Type: application/json
+
+["speech_1", "speech_2", "speech_3"]
+--jhgd87g7Gy3d78--
+```
+
+
+### Response
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Location: https://api.itslanguage.nl/categories/category_3
+
+{
+  "id": "category_3",
+  "created": "2017-01-12T09:50:20Z",
+  "updated": "2017-01-12T09:50:20Z",
+  "name": "Category 3",
+  "description": "Category three. Winner of all categories. Yes.",
+  "color": "#e3e3e3",
+  "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+  "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
+  "categories": [],
+  "speechChallenges": ["speech_1", "speech_2", "speech_3"]
+}
+```
+
+## Update a category
+
+### URL
+
+```http
+PUT /categories/:category HTTP/1.1
+```
+
+* `category` - **Required** The category identifier.
+
+Update one or more properties of an existing category
+
+### Request parameters
+
+Name               | Type      | Description
+-------------------|-----------|------------
+`name`             | `string`  | **Optional** A name for the category.
+`description`      | `string`  | **Optional** A possible more verbose description about the category.
+`color`            | `string`  | **Optional** A color, preferably in RGB format.
+`image`            | `blob`    | **Optional** An image to show with the category.
+`icon`             | `blob`    | **Optional** An icon to show with the category.
+`categories`       | `object`  | **Optional** An array with category identifiers for nesting categories in a category.
+`speechChallenges` | `object`  | **Optional** An array of Speech Challenges identifiers categorized in the category.
+
+## Request
+
+```http
+PUT /categories/category_3 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+
+{
+  "categories": ["categorie_3_1"]
+}
+```
+
+### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Location: https://api.itslanguage.nl/categories/category_3
+
+{
+  "id": "category_3",
+  "created": "2017-01-12T09:50:20Z",
+  "updated": "2017-01-12T09:50:20Z",
+  "name": "Category 3",
+  "description": "Category three. Winner of all categories. Yes.",
+  "color": "#e3e3e3",
+  "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+  "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
+  "categories": ["category_3_1"],
+  "speechChallenges": ["speech_1", "speech_2", "speech_3"]
+}
+```

--- a/docs/api/categories.md
+++ b/docs/api/categories.md
@@ -1,4 +1,4 @@
-# Cagegories
+# Categories
 
 Categorize Speech Challenges or categories.
 
@@ -21,7 +21,7 @@ Accept: application/json
 
 ### Response
 
-The resonse is a JSON list with categories.
+The response is a JSON list with categories.
 
 ```http
 HTTP/1.1 200 OK

--- a/docs/api/categories.md
+++ b/docs/api/categories.md
@@ -30,6 +30,7 @@ Content-Type: application/json
 [
   {
     "id": "category_1",
+    "parent": null,
     "created": "2017-01-12T09:35:20Z",
     "updated": "2017-01-12T09:35:20Z",
     "name": "Category 1",
@@ -38,14 +39,11 @@ Content-Type: application/json
     "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
     "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
     "categories": ["category_1_1", "category_1_2"],
-    "speechChallenges": [],
-    "progress": {
-      "done": 1,
-      "total": 2
-    }
+    "speechChallenges": []
   },
   {
     "id": "category_2",
+    "parent": null,
     "created": "2017-01-12T09:36:20Z",
     "updated": "2017-01-12T09:36:20Z",
     "name": "Category 2",
@@ -53,12 +51,7 @@ Content-Type: application/json
     "color": "#0f0",
     "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
     "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
-    "categories": ["category_2_1", "category_2_2", "category_2_3"],
-    "speechChallenges": [],
-    "progress": {
-      "done": 1,
-      "total": 3
-    }
+    "speechChallenges": []
   }
 ]
 ```
@@ -88,14 +81,14 @@ Content-Type: application/json
 
 {
   "id": "category_1_1",
+  "parent": "category_1"
   "created": "2017-01-12T09:38:20Z",
   "updated": "2017-01-12T09:38:20Z",
   "name": "Category 1.1",
   "description": "Super duper.",
-  "color": "",
-  "imageUrl": "",
-  "iconUrl": "",
-  "categories": [],
+  "color": null,
+  "imageUrl": null,
+  "iconUrl": null,
   "speechChallenges": [
     {
       "id": "speech_1",
@@ -115,11 +108,7 @@ Content-Type: application/json
       "srtUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
       "imageUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe"
     }
-  ],
-  "progress": {
-    "done": 1,
-    "total": 2
-  }
+  ]
 }
 ```
 
@@ -136,12 +125,12 @@ POST /categories/category HTTP/1.1
 Name               | Type      | Description
 -------------------|-----------|------------
 `id`               | `string`  | **Optional** The category identifier. If none is given, one is generated.
+`parent`           | `string`  | **Optional** Identifier of the parent category.
 `name`             | `string`  | **Optional** A name for the category.
 `description`      | `string`  | **Optional** A possible more verbose description about the category.
 `color`            | `string`  | **Optional** A color, preferably in RGB format.
 `image`            | `blob`    | **Optional** An image to show with the category.
 `icon`             | `blob`    | **Optional** An icon to show with the category.
-`categories`       | `object`  | **Optional** An array with category identifiers for nesting categories in a category.
 `speechChallenges` | `object`  | **Optional** An array of Speech Challenges identifiers categorized in the category.
 
 #### Request
@@ -202,7 +191,6 @@ Location: https://api.itslanguage.nl/categories/category_3
   "color": "#e3e3e3",
   "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
   "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
-  "categories": [],
   "speechChallenges": ["speech_1", "speech_2", "speech_3"]
 }
 ```
@@ -223,23 +211,23 @@ Update one or more properties of an existing category
 
 Name               | Type      | Description
 -------------------|-----------|------------
+`parent`           | `string`  | **Optional** Identifier of the parent category.
 `name`             | `string`  | **Optional** A name for the category.
 `description`      | `string`  | **Optional** A possible more verbose description about the category.
 `color`            | `string`  | **Optional** A color, preferably in RGB format.
 `image`            | `blob`    | **Optional** An image to show with the category.
 `icon`             | `blob`    | **Optional** An icon to show with the category.
-`categories`       | `object`  | **Optional** An array with category identifiers for nesting categories in a category.
 `speechChallenges` | `object`  | **Optional** An array of Speech Challenges identifiers categorized in the category.
 
 ## Request
 
 ```http
-PUT /categories/category_3 HTTP/1.1
+PUT /categories/category_3_1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 
 {
-  "categories": ["categorie_3_1"]
+  "parent": ["categorie_3"]
 }
 ```
 
@@ -251,7 +239,8 @@ Content-Type: application/json
 Location: https://api.itslanguage.nl/categories/category_3
 
 {
-  "id": "category_3",
+  "id": "category_3_1",
+  "parent" "category_3",
   "created": "2017-01-12T09:50:20Z",
   "updated": "2017-01-12T09:50:20Z",
   "name": "Category 3",
@@ -259,7 +248,6 @@ Location: https://api.itslanguage.nl/categories/category_3
   "color": "#e3e3e3",
   "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
   "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
-  "categories": ["category_3_1"],
   "speechChallenges": ["speech_1", "speech_2", "speech_3"]
 }
 ```

--- a/docs/api/categories.md
+++ b/docs/api/categories.md
@@ -56,12 +56,64 @@ Content-Type: application/json
 ]
 ```
 
-# Get a single category
+## Listing all categories with same parent
+
+A category can be parent of another category (nesting). In order to get all categories with the same parent, this url can be used.
 
 ### URL
 
 ```http
-GET /category/:category HTTP/1.1
+GET /categories/:category/categories HTTP/1.1
+```
+
+### Request
+
+```http
+GET /categories/category_1/categories HTTP/1.1
+Accept: application/json
+```
+
+### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "id": "category_1_1",
+    "parent": "category_1",
+    "created": "2017-01-13T09:35:20Z",
+    "updated": "2017-01-13T09:35:20Z",
+    "name": "Category 1.1",
+    "description": "Some awesome description.",
+    "color": "#00f",
+    "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+    "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
+    "categories": ["category_1_1", "category_1_2"],
+    "speechChallenges": ["speech_x"]
+  },
+  {
+    "id": "category_1_2",
+    "parent": "category_1",
+    "created": "2017-01-13T09:36:20Z",
+    "updated": "2017-01-13T09:36:20Z",
+    "name": "Category 1.2",
+    "description": "Another awesome description.",
+    "color": "#0f0",
+    "imageUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
+    "iconUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe",
+    "speechChallenges": ["speech_y", "speech_w"]
+  }
+]
+```
+
+## Get a single category
+
+### URL
+
+```http
+GET /categories/:category HTTP/1.1
 ```
 
 * `category` - **Required** The category identifier.
@@ -69,7 +121,7 @@ GET /category/:category HTTP/1.1
 ### Request
 
 ```http
-GET /category/category_1_1 HTTP/1.1
+GET /categories/category_1_1 HTTP/1.1
 Accept: application/json
 ```
 
@@ -89,30 +141,11 @@ Content-Type: application/json
   "color": null,
   "imageUrl": null,
   "iconUrl": null,
-  "speechChallenges": [
-    {
-      "id": "speech_1",
-      "created": "2014-01-28T21:25:10Z",
-      "updated": "2014-01-28T21:25:10Z",
-      "topic": "What do you know about babies?",
-      "referenceAudioUrl": "https://api.itslanguage.nl/download/YsjdG37bUGseu8-bsJ",
-      "srtUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
-      "imageUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe"
-    },
-    {
-      "id": "12",
-      "created": "2014-01-28T21:25:10Z",
-      "updated": "2014-01-28T21:25:10Z",
-      "topic": "Book",
-      "referenceAudioUrl": "https://api.itslanguage.nl/download/YsjdG37bUGseu8-bsJ",
-      "srtUrl": "https://api.itslanguage.nl/download/UKbsMpBsXaJUsBbK",
-      "imageUrl": "https://api.itslanguage.nl/download/GdExSbs-ZVNnQUUe"
-    }
-  ]
+  "speechChallenges": ["speech_1", "12"]
 }
 ```
 
-### Create a catetory
+## Create a catetory
 
 ### URL
 
@@ -133,7 +166,7 @@ Name               | Type      | Description
 `icon`             | `blob`    | **Optional** An icon to show with the category.
 `speechChallenges` | `object`  | **Optional** An array of Speech Challenges identifiers categorized in the category.
 
-#### Request
+### Request
 
 ```http
 POST /categories/category HTTP/1.1
@@ -219,7 +252,7 @@ Name               | Type      | Description
 `icon`             | `blob`    | **Optional** An icon to show with the category.
 `speechChallenges` | `object`  | **Optional** An array of Speech Challenges identifiers categorized in the category.
 
-## Request
+### Request
 
 ```http
 PUT /categories/category_3_1 HTTP/1.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ pages:
     - 'Speech Recordings': 'api/recordings.md'
     - 'Speech Analysis': 'api/analyses.md'
     - 'Speech Recognition': 'api/recognitions.md'
+    - 'Category': 'api/categories.md'
     - 'Tenants': 'api/tenants.md'
     - Users:
         - 'Users': 'api/users.md'


### PR DESCRIPTION
Add API documentation for the Category object.
Some posible discussion points are:

- How are the nested categories being returned?
 If there is nesting multiple levels deep, it might not be wise to return all the nested categories inline. My suggestion is to return a list (array) with all the nested categories. I'm not sure how this affects the progress!
- How are the nested speech challenges being returned?
 Same as with the nested categories but since this is only one level deep I would suggest to just include them in the result.
- How are the (eventually) nested categories and or speech challenges being returned after updating or creating an category? Can we leave out fields (like progress) when creating a category?
 My suggestion would be to show as minimal as possible on create. This feature will not be used in a fronted directly (possible in a sort of CMS solution).