### PR TITLE
docs(categories): prefix with group url

### DIFF
--- a/docs/api/categories.md
+++ b/docs/api/categories.md
@@ -9,13 +9,15 @@ List all top level categories which do not have a parent category.
 ### URL
 
 ```http
-GET /categories HTTP/1.1
+GET /groups/:group/categories HTTP/1.1
 ```
+
+* `group` - **Required** The group identifier.
 
 ### Request
 
 ```http
-GET /categories HTTP/1.1
+GET /groups/:group/categories HTTP/1.1
 Accept: application/json
 ```
 
@@ -62,13 +64,16 @@ A category can be parent of another category (nesting). In order to get all cate
 ### URL
 
 ```http
-GET /categories/:category/categories HTTP/1.1
+GET /groups/:group/categories/:category/categories HTTP/1.1
 ```
+
+* `category` - **Required** The category identifier.
+* `group` - **Required** The group identifier.
 
 ### Request
 
 ```http
-GET /categories/category_1/categories HTTP/1.1
+GET /groups/:group/categories/category_1/categories HTTP/1.1
 Accept: application/json
 ```
 
@@ -111,15 +116,16 @@ Content-Type: application/json
 ### URL
 
 ```http
-GET /categories/:category HTTP/1.1
+GET /groups/:group/categories/:category HTTP/1.1
 ```
 
 * `category` - **Required** The category identifier.
+* `group` - **Required** The group identifier.
 
 ### Request
 
 ```http
-GET /categories/category_1_1 HTTP/1.1
+GET /groups/:group/categories/category_1_1 HTTP/1.1
 Accept: application/json
 ```
 
@@ -148,8 +154,10 @@ Content-Type: application/json
 ### URL
 
 ```http
-POST /categories HTTP/1.1
+POST /groups/:group/categories HTTP/1.1
 ```
+
+* `group` - **Required** The group identifier.
 
 ### Request parameters
 
@@ -167,7 +175,7 @@ Name               | Type      | Description
 ### Request
 
 ```http
-POST /categories HTTP/1.1
+POST /groups/:group/categories HTTP/1.1
 Accept: application/json
 Content-Type: multipart/form-data; boundary=jhgd87g7Gy3d78
 
@@ -238,10 +246,11 @@ Location: https://api.itslanguage.nl/categories/category_3
 ### URL
 
 ```http
-PUT /categories/:category HTTP/1.1
+PUT /groups/:group/categories/:category HTTP/1.1
 ```
 
 * `category` - **Required** The category identifier.
+* `group` - **Required** The group identifier.
 
 Update one or more properties of an existing category
 
@@ -260,7 +269,7 @@ Name               | Type      | Description
 ### Request
 
 ```http
-PUT /categories/category_3_1 HTTP/1.1
+PUT /groups/:group/categories/category_3_1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 


### PR DESCRIPTION
Prefix the category api with the group api url.

Closes #41