### PR TITLE
refactor(choice_recognitions): move rpc registration to wamp

### DIFF
--- a/docs/websocket/choice_recognitions.md
+++ b/docs/websocket/choice_recognitions.md
@@ -6,7 +6,7 @@ To perform a choice recognition a number of steps have to be made:
 
 1. [Initialising a choice recognition](#initialising-a-choice-recognition)
 2. [Initialise choice challenge](#initialise-choice-challenge)
-3. [Register audio procedure](#register-audio-procedure)
+3. [Register audio procedure](wamp.md#register-audio-procedure)
 4. [Perform the recognition](#perform-the-recognition)
 
 
@@ -54,33 +54,6 @@ organisation_id | `string` | **Required** The id of the organisation in which to
 challenge_id    | `string` | **Required** The id of the challenge to prepare.
 
 
-## Register audio procedure
-
-To send audio for recognition a WAMP procedure must be registered. Check your
-WAMP library's documentation on how to do this. Some are linked here:
-
-* [Autobahn-js][1]
-* [Autobahn|Python][2]
-
-The procedure must return [progressive results], check your library's
-documentation on how to implement this. Every progressive result is a chunk of
-the audio and so audio is sent in chunks.
-Later on, the server will call this procedure to 'pull' the audio in. When the
-procedure returns, the stream is finished/closed.
-
-Note that a complete (self-describing) audio file is expected, starting with a
-header. Check [the audio documentation page](audio.md#self-describing-formats)
-to see more about supported formats.
-
-The procedure can best be registered to a randomly generated URI, using uuid4
-for this is advisable to ensure uniqueness. For every audio a separate procedure
-must be registered. The URI is used later on.
-It is advisable to unregister the procedure when the streaming is finished.
-
-!!! warning
-    Re-using a URI can result in conflicts.
-
-
 ## Perform the recognition
 
 The recognition can be performed when all preparations are done.
@@ -96,7 +69,7 @@ nl.itslanguage.choice.recognise
 Name           | Type     | Description
 ---------------|----------|------------
 recognition_id | `string` | **Required** The id of the recognition to perform.
-rpc            | `string` | **Required** The URI of the registered audio rpc.
+rpc            | `string` | **Required** The URI of a [registered audio rpc](wamp.md#register-audio-procedure).
 
 ### Response
 

--- a/docs/websocket/wamp.md
+++ b/docs/websocket/wamp.md
@@ -8,3 +8,30 @@ Other [implementations](http://wamp-proto.org/implementations/) are also
 available.
 
 [WAMP]: http://wamp-proto.org
+
+
+## Register audio procedure
+
+To send audio, a WAMP procedure must be registered. Check your
+WAMP library's documentation on how to do this. Some are linked here:
+
+* [Autobahn-js][1]
+* [Autobahn|Python][2]
+
+The procedure must return [progressive results], check your library's
+documentation on how to implement this. Every progressive result is a chunk of
+the audio and so audio is sent in chunks.
+Later on, the server will call this procedure to 'pull' the audio in. When the
+procedure returns, the stream is finished/closed.
+
+Note that a complete (self-describing) audio file is expected, starting with a
+header. Check [the audio documentation page](audio.md#self-describing-formats)
+to see more about supported formats.
+
+The procedure can best be registered to a randomly generated URI, using uuid4
+for this is advisable to ensure uniqueness. For every audio a separate procedure
+must be registered. The URI is used later on.
+It is advisable to unregister the procedure when the streaming is finished.
+
+!!! warning
+    Re-using a URI can result in conflicts.


### PR DESCRIPTION
Move instructions on how to register an audio rpc to the wamp page. This
way the instructions can be reused more cleanly.