### PR TITLE
docs(feedback): remove challenge from the url

### DIFF
--- a/docs/api/feedback.md
+++ b/docs/api/feedback.md
@@ -9,18 +9,17 @@ The feedback is created for the current user.
 ### URL
 
 ```http
-POST /challenges/speech/:challenge/feedback HTTP/1.1
+POST /feedback HTTP/1.1
 ```
-
-* challenge - **Required** The id of the speech challenge used to perform the feedback.
 
 ### Request parameters
 
-Name     | Type     | Description
----------|----------|------------
-id       | `string` | **Optional** The id of the feedback. If none is given, one is generated.
-audio    | `blob`   | **Required** The recorded audio.
-feedback | `bool`   | **Required** The feedback as received per sentence.
+Name      | Type     | Description
+----------|----------|------------
+id        | `string` | **Optional** The id of the feedback. If none is given, one is generated.
+audio     | `blob`   | **Required** The recorded audio.
+challenge | `string` | **Required** The id of the speech challenge used to perform the feedback.
+feedback  | `bool`   | **Required** The feedback as received per sentence.
 
 ### Request
 
@@ -29,10 +28,14 @@ The request should be a `multipart/form-data`.
 Example:
 
 ```http
-POST /challenges/speech/test/feedback HTTP/1.1
+POST /feedback HTTP/1.1
 Accept: application/json
 Content-Type: multipart/form-data; boundary="YvHKkjjzXfysYJVHMoOAoNczae"
 
+--YvHKkjjzXfysYJVHMoOAoNczae
+Content-Disposition: form-data; name="challenge"
+
+chal
 --YvHKkjjzXfysYJVHMoOAoNczae
 Content-Disposition: form-data; name="audio"; filename="blob"
 Content-Type: audio/ogg
@@ -63,6 +66,7 @@ Content-Type: application/json
   "updated": "2018-02-20T09:39:40Z",
   "created": "2018-02-20T09:39:37Z",
   "audioUrl": "https://api.itslanguage.nl/download/YsjdG37bUGseu8-bsJ",
+  "challenge": "chal",
   "feedback": [
     true,
     false


### PR DESCRIPTION
Instead of having the challenge in the url, put it in the body. This
makes the url simpler. Now the id of the challenge isn't needed when
getting the feedback for example.