### PR TITLE
fix(feedback): include feedback_id in example

### DIFF
--- a/docs/websocket/feedback.md
+++ b/docs/websocket/feedback.md
@@ -62,6 +62,7 @@ the following json is sent as a progressive result:
 
 ```json
 {
+  "feedback_id": "recording_1",
   "sentence": 0,
   "feedback": true
 }


### PR DESCRIPTION
The "feedback_id" was missing in one of the example output. Include it
to have a more realistic example.