### PR TITLE
feat(feedback): add extra data field

### DIFF
--- a/docs/api/feedback.md
+++ b/docs/api/feedback.md
@@ -20,6 +20,7 @@ id          | `string` | **Optional** The id of the feedback. If none is given, 
 audio       | `blob`   | **Required** The recorded audio.
 challengeId | `string` | **Required** The id of the speech challenge used to perform the feedback.
 errors      | `int`    | **Required** The amount of errors made per sentence.
+extra       | `json`   | **Optional** Extra data to store.
 
 ### Request
 
@@ -49,6 +50,11 @@ Content-Disposition: form-data; name="errors"
 Content-Disposition: form-data; name="errors"
 
 2
+--YvHKkjjzXfysYJVHMoOAoNczae
+Content-Disposition: form-data; name="extra"
+Content-Type: application/json
+
+{'note': 'cheap microphone'}
 --YvHKkjjzXfysYJVHMoOAoNczae--
 ```
 
@@ -71,6 +77,9 @@ Content-Type: application/json
     0,
     1
   ],
+  "extra": {
+    "note": "cheap microphone"
+  },
   "userId": "24"
 }
 ```
@@ -116,6 +125,9 @@ Content-Type: application/json
     0,
     2
   ],
+  "extra": {
+    "note": "cheap microphone"
+  },
   "userId": "24"
 }
 ```


### PR DESCRIPTION
Add a field to store extra data in a structured way.

This is to store the final asr output in. Is this the way to go?
Note that anyone with read access can also read this extra data field. If we want to keep the asr internal I think we should opt for a dedicated field.
On the plus side, the `extra` field is extendable, so more arbitrary data can be stored in it.