### PR TITLE
Update speechchallenge fields

### DIFF
--- a/docs/api/speech_challenges.md
+++ b/docs/api/speech_challenges.md
@@ -41,7 +41,7 @@ Content-Type: application/json
     "id": "12",
     "created": "2014-01-28T21:25:10Z",
     "updated": "2014-01-28T21:25:10Z",
-    "language": null,
+    "language": "eng",
     "topic": "Book",
     "referenceAudioUrl": null,
     "srtUrl": null,
@@ -101,7 +101,7 @@ POST /challenges/speech HTTP/1.1
 | ---------------- | -------- | --------------------------------------------------------------------------------- |
 | `id`             | `string` | **Optional** The speech challenge identifier. If none is given, one is generated. |
 | `topic`          | `string` | **Optional** A question or topic serving as guidance to the student.              |
-| `language`       | `string` | **Optional** Language of the challenge in ISO 639-2 format.                       |
+| `language`       | `string` | **Required** Language of the challenge in ISO 639-2 format.                       |
 | `referenceAudio` | `blob`   | **Optional** The reference audio fragment.                                        |
 | `srt`            | `blob`   | **Optional** The transcription of the challenge in `.srt` format.                 |
 | `image`          | `blob`   | **Optional** An image to show with the challenge.                                 |
@@ -176,8 +176,8 @@ Update one or more properties of an existing speech challenge.
 
 | Name             | Type     | Description                                                          |
 | ---------------- | -------- | -------------------------------------------------------------------- |
-| `topic`          | `string` | **Optional** A question or topic serving as guidance to the student. |
-| `language`       | `string` | **Optional** Language of the challenge in ISO 639-2 format.          |
+| `topic`          | `string` | **Required** A question or topic serving as guidance to the student. |
+| `language`       | `string` | **Required** Language of the challenge in ISO 639-2 format.          |
 | `referenceAudio` | `blob`   | **Optional** The reference audio fragment.                           |
 | `srt`            | `blob`   | **Optional** The transcription of the challenge in `.srt` format.    |
 | `image`          | `blob`   | **Optional** An image to show with the challenge.                    |

--- a/docs/api/speech_challenges.md
+++ b/docs/api/speech_challenges.md
@@ -34,7 +34,8 @@ Content-Type: application/json
     "topic": "What do you know about babies?",
     "referenceAudioUrl": "https://api.itslanguage.io/download/YsjdG37bUGseu8-bsJ",
     "srtUrl": "https://api.itslanguage.io/download/UKbsMpBsXaJUsBbK",
-    "imageUrl": "https://api.itslanguage.io/download/GdExSbs-ZVNnQUUe"
+    "imageUrl": "https://api.itslanguage.io/download/GdExSbs-ZVNnQUUe",
+    "metadata": null
   },
   {
     "id": "12",
@@ -43,7 +44,8 @@ Content-Type: application/json
     "topic": "Book",
     "referenceAudioUrl": null,
     "srtUrl": null,
-    "imageUrl": null
+    "imageUrl": null,
+    "metadata": null
   }
 ]
 ```
@@ -79,7 +81,8 @@ Content-Type: application/json
   "topic": "What do you know about babies?",
   "referenceAudioUrl": "https://api.itslanguage.io/download/YsjdG37bUGseu8-bsJ",
   "srtUrl": "https://api.itslanguage.io/download/zVXLJJuGyhBHQbfX",
-  "imageUrl": "https://api.itslanguage.io/download/dlnBo-dotLpnhN-a"
+  "imageUrl": "https://api.itslanguage.io/download/dlnBo-dotLpnhN-a",
+  "metadata": null
 }
 ```
 
@@ -148,7 +151,8 @@ Location: https://api.itslanguage.io/challenges/speech/4
   "topic": "What do you know about babies?",
   "referenceAudioUrl": "https://api.itslanguage.io/download/YsjdG37bUGseu8-bsJ",
   "srtUrl": "https://api.itslanguage.io/download/QEYduwrFRHeufiru",
-  "imageUrl": "https://api.itslanguage.io/download/h-JJREJRCFAeA-nl"
+  "imageUrl": "https://api.itslanguage.io/download/h-JJREJRCFAeA-nl",
+  "metadata": null
 }
 ```
 
@@ -201,6 +205,7 @@ Location: https://api.itslanguage.io/challenges/speech/4
   "topic": "What do you know about the baby?",
   "referenceAudioUrl": "https://api.itslanguage.io/download/cxtczOCmVbvVsIFw",
   "srtUrl": "https://api.itslanguage.io/download/acfRSlgOorYdeYcP",
-  "imageUrl": "https://api.itslanguage.io/download/xCbFikceYVgUIHqc"
+  "imageUrl": "https://api.itslanguage.io/download/xCbFikceYVgUIHqc",
+  "metadata": null
 }
 ```

--- a/docs/api/speech_challenges.md
+++ b/docs/api/speech_challenges.md
@@ -2,7 +2,6 @@
 
 Guide the student in speaking through an optional topic and optional reference audio.
 
-
 ## List all speech challenges
 
 ### URL
@@ -32,6 +31,7 @@ Content-Type: application/json
     "created": "2014-01-28T21:25:10Z",
     "updated": "2014-01-28T21:25:10Z",
     "topic": "What do you know about babies?",
+    "language": "eng",
     "referenceAudioUrl": "https://api.itslanguage.io/download/YsjdG37bUGseu8-bsJ",
     "srtUrl": "https://api.itslanguage.io/download/UKbsMpBsXaJUsBbK",
     "imageUrl": "https://api.itslanguage.io/download/GdExSbs-ZVNnQUUe",
@@ -41,6 +41,7 @@ Content-Type: application/json
     "id": "12",
     "created": "2014-01-28T21:25:10Z",
     "updated": "2014-01-28T21:25:10Z",
+    "language": null,
     "topic": "Book",
     "referenceAudioUrl": null,
     "srtUrl": null,
@@ -50,7 +51,6 @@ Content-Type: application/json
 ]
 ```
 
-
 ## Get a single speech challenge
 
 ### URL
@@ -59,7 +59,7 @@ Content-Type: application/json
 GET /challenges/speech/:challenge HTTP/1.1
 ```
 
-* `challenge` - **Required** The speech challenge identifier.
+- `challenge` - **Required** The speech challenge identifier.
 
 ### Request
 
@@ -79,13 +79,13 @@ Content-Type: application/json
   "created": "2014-01-28T21:25:10Z",
   "updated": "2014-01-28T21:25:10Z",
   "topic": "What do you know about babies?",
+  "language": "eng",
   "referenceAudioUrl": "https://api.itslanguage.io/download/YsjdG37bUGseu8-bsJ",
   "srtUrl": "https://api.itslanguage.io/download/zVXLJJuGyhBHQbfX",
   "imageUrl": "https://api.itslanguage.io/download/dlnBo-dotLpnhN-a",
   "metadata": null
 }
 ```
-
 
 ## Create a speech challenge
 
@@ -97,15 +97,15 @@ POST /challenges/speech HTTP/1.1
 
 ### Request parameters
 
-Name             | Type     | Description
------------------|----------|------------
-`id`             | `string` | **Optional** The speech challenge identifier. If none is given, one is generated.
-`topic`          | `string` | **Optional** A question or topic serving as guidance to the student.
-`referenceAudio` | `blob`   | **Optional** The reference audio fragment.
-`srt`            | `blob`   | **Optional** The transcription of the challenge in `.srt` format.
-`image`          | `blob`   | **Optional** An image to show with the challenge.
-`metadata`       | `string` | **Optional** Client specific properties that are not validated nor filtered.
-
+| Name             | Type     | Description                                                                       |
+| ---------------- | -------- | --------------------------------------------------------------------------------- |
+| `id`             | `string` | **Optional** The speech challenge identifier. If none is given, one is generated. |
+| `topic`          | `string` | **Optional** A question or topic serving as guidance to the student.              |
+| `language`       | `string` | **Optional** Language of the challenge in ISO 639-2 format.                       |
+| `referenceAudio` | `blob`   | **Optional** The reference audio fragment.                                        |
+| `srt`            | `blob`   | **Optional** The transcription of the challenge in `.srt` format.                 |
+| `image`          | `blob`   | **Optional** An image to show with the challenge.                                 |
+| `metadata`       | `string` | **Optional** Client specific properties that are not validated nor filtered.      |
 
 #### Request
 
@@ -124,6 +124,10 @@ Content-Disposition: form-data; name="topic"
 
 What do you know about babies?
 --jhgd87g7Gy3d78
+Content-Disposition: form-data; name="language"
+
+eng
+--jhgd87g7Gy3d78
 Content-Disposition: form-data; name="srt"; filename="chal.srt"
 Content-Type: text/plain
 
@@ -135,7 +139,6 @@ Content-Type: image/png
 <blob>
 --jhgd87g7Gy3d78--
 ```
-
 
 ### Response
 
@@ -149,13 +152,13 @@ Location: https://api.itslanguage.io/challenges/speech/4
   "created": "2014-01-28T21:25:10Z",
   "updated": "2014-01-28T21:25:10Z",
   "topic": "What do you know about babies?",
+  "language": "eng",
   "referenceAudioUrl": "https://api.itslanguage.io/download/YsjdG37bUGseu8-bsJ",
   "srtUrl": "https://api.itslanguage.io/download/QEYduwrFRHeufiru",
   "imageUrl": "https://api.itslanguage.io/download/h-JJREJRCFAeA-nl",
   "metadata": null
 }
 ```
-
 
 ## Update a speech challenge
 
@@ -165,19 +168,19 @@ Location: https://api.itslanguage.io/challenges/speech/4
 PUT /challenges/speech/:challenge HTTP/1.1
 ```
 
-* `challenge` - **Required** The speech challenge identifier.
+- `challenge` - **Required** The speech challenge identifier.
 
 Update one or more properties of an existing speech challenge.
 
 ### Request parameters
 
-Name             | Type     | Description
------------------|----------|------------
-`topic`          | `string` | **Optional** A question or topic serving as guidance to the student.
-`referenceAudio` | `blob`   | **Optional** The reference audio fragment.
-`srt`            | `blob`   | **Optional** The transcription of the challenge in `.srt` format.
-`image`          | `blob`   | **Optional** An image to show with the challenge.
-
+| Name             | Type     | Description                                                          |
+| ---------------- | -------- | -------------------------------------------------------------------- |
+| `topic`          | `string` | **Optional** A question or topic serving as guidance to the student. |
+| `language`       | `string` | **Optional** Language of the challenge in ISO 639-2 format.          |
+| `referenceAudio` | `blob`   | **Optional** The reference audio fragment.                           |
+| `srt`            | `blob`   | **Optional** The transcription of the challenge in `.srt` format.    |
+| `image`          | `blob`   | **Optional** An image to show with the challenge.                    |
 
 ### Request
 
@@ -203,6 +206,7 @@ Location: https://api.itslanguage.io/challenges/speech/4
   "created": "2014-01-28T21:25:10Z",
   "updated": "2014-01-28T21:25:10Z",
   "topic": "What do you know about the baby?",
+  "language": "eng",
   "referenceAudioUrl": "https://api.itslanguage.io/download/cxtczOCmVbvVsIFw",
   "srtUrl": "https://api.itslanguage.io/download/acfRSlgOorYdeYcP",
   "imageUrl": "https://api.itslanguage.io/download/xCbFikceYVgUIHqc",

--- a/docs/websocket/feedback.md
+++ b/docs/websocket/feedback.md
@@ -4,10 +4,19 @@ It's possible to get feedback while recording. After every sentence feedback is
 provided indicating whether or not the sentence was read well.
 To perform a recording with feedback the following calls have to be made:
 
-1. [Prepare the speech feedback](#prepare)
-2. [Register audio procedure for streaming](wamp.md#register-audio-procedure)
-3. [Start listening for audio](#listen)
+1. [Meet prerequisites](#prerequisites)
+2. [Prepare the speech feedback](#prepare)
+3. [Register audio procedure for streaming](wamp.md#register-audio-procedure)
+4. [Start listening for audio](#listen)
 
+## Prerequisites
+
+To be able to do speech feedback the following prerequisites needs to be met:
+
+- A speech challenge must be used so that needs to exist.
+- The speech challenges needs to have the language set
+- The user performing the speech feedback needs to have a valid profile with
+  birthYear and language set.
 
 ## Prepare
 


### PR DESCRIPTION
## Changed

- metadata was missing from the examples;
- Prettier was run on the `speech_challenges.md` file which happened unintentionally but changes are fine

## Added

- The language field was missing in the Speech Challenge api docs
- Prerequisites on when wanting to take the speech feedback challenge